### PR TITLE
Fixed bug in get_pixel_matrix()

### DIFF
--- a/extract_image.py
+++ b/extract_image.py
@@ -10,9 +10,9 @@ def get_pixel_matrix(image):
 
     data = image.getdata()
 
-    image = np.asarray(data, np.dtype('int,int,int,int'))
+    image_array = np.asarray(data, np.dtype('int,int,int,int'))
 
-    return image.reshape(image.size)
+    return image_array.reshape(image.size)
 
 def resize_image(image, size=None, height=None, width=None):
     """


### PR DESCRIPTION
Created variable 'image_array' different from 'image' since we want to preserve the original value of image.size in line 15.